### PR TITLE
perf(Tactic/Linarith/Parsing): syntactic HashMap fast path on findDefeq

### DIFF
--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -131,11 +131,37 @@ open Lean Elab Tactic Meta
 
 /--
 `ExprMap` is used to record atomic expressions which have been seen while processing inequality
-expressions.
+expressions. We keep both a `List` (preserving insertion order for the defeq-scan fallback and
+for downstream atom-array reconstruction) and a `Std.HashMap` keyed on syntactic equality. For
+typical linarith inputs — `FVar`s, simple applications — most lookups hit a previously-seen
+atom syntactically, so the HashMap shortcuts the O(n) `isDefEq` scan to O(1).
 -/
--- The natural number is just the index in the list,
--- and we could reimplement to just use `List Expr` if desired.
-abbrev ExprMap := List (Expr × ℕ)
+structure ExprMap where
+  /-- Most-recent-first list of seen atoms paired with their indices. The list is the source
+  of truth for both `findDefeq` (defeq scan) and downstream atom-array reconstruction. -/
+  list : List (Expr × ℕ) := []
+  /-- Acceleration structure for `findDefeq`: a syntactic-equality map that is kept consistent
+  with `list` by going through `push`. The hash lookup can never produce a wrong answer because
+  `Std.HashMap.insert` overwrites on syntactic match and `list` is most-recent-first, so a cache
+  hit always matches what the defeq scan would return for the same input. -/
+  cache : Std.HashMap Expr ℕ := {}
+  deriving Inhabited
+
+namespace ExprMap
+
+@[inline] def length (m : ExprMap) : ℕ := m.list.length
+
+/-- Add `(e, n)` to both `list` (at the head) and `cache`. -/
+@[inline] def push (m : ExprMap) (e : Expr) (n : ℕ) : ExprMap :=
+  { list := (e, n) :: m.list, cache := m.cache.insert e n }
+
+/-- Find the index of a key defeq to `e` (up to transparency `red`). Tries the syntactic
+hash cache first; on miss falls back to the defeq list scan. Both paths agree by construction. -/
+@[inline] def findDefeq (m : ExprMap) (red : TransparencyMode) (e : Expr) : MetaM ℕ := do
+  if let some n := m.cache[e]? then return n
+  m.list.findDefeq red e
+
+end ExprMap
 
 /--
 `linearFormOfAtom red map e` is the atomic case for `linear_form_of_expr`.
@@ -148,7 +174,7 @@ def linearFormOfAtom (red : TransparencyMode) (m : ExprMap) (e : Expr) : MetaM (
     return (m, var k)
   catch _ =>
     let n := m.length + 1
-    return ((e, n)::m, var n)
+    return (m.push e n, var n)
 
 /--
 `linearFormOfExpr red map e` computes the linear form of `e`.
@@ -246,7 +272,7 @@ It also returns the largest variable index that appears in comparisons in `c`.
 def linearFormsAndMaxVar (red : TransparencyMode) (pfs : List Expr) :
     MetaM (List Comp × ℕ × ExprMap × Map Monom ℕ) := do
   let pftps ← (pfs.mapM inferType)
-  let (l, exprMap, map) ← toCompFold red [] pftps TreeMap.empty
+  let (l, exprMap, map) ← toCompFold red {} pftps TreeMap.empty
   trace[linarith.detail] "monomial map: {map.toList.map fun ⟨k,v⟩ => (k.toList, v)}"
   return (l, map.size - 1, exprMap, map)
 

--- a/Mathlib/Tactic/Linarith/Verification.lean
+++ b/Mathlib/Tactic/Linarith/Verification.lean
@@ -216,7 +216,7 @@ def proveFalseByLinarith (transparency : TransparencyMode) (oracle : Certificate
       -- Build the atom array indexed by linarith's atom number (1-based).
       let atomsArr : Array Expr := Id.run do
         let mut arr : Array Expr := Array.replicate (exprMap.length + 1) (mkConst ``Unit)
-        for (e, k) in exprMap do
+        for (e, k) in exprMap.list do
           if h : k < arr.size then arr := arr.set k e h
         pure arr
       trace[linarith.detail] "comps:{indentD <| toMessageData comps}"


### PR DESCRIPTION
This PR is the actual fix. `linarith`'s atomization (`linearFormsAndMaxVar`) used `ExprMap := List (Expr × ℕ)` and looked up each atom occurrence with `List.findDefeq` — a linear scan with `isDefEq` against every previously-seen atom. On Size80 (160 hypotheses × ~80 distinct atoms) that's up to ~10k `isDefEq` calls in the atomization stage alone.

Replace `ExprMap` with a struct wrapping both the original `List` and a `Std.HashMap Expr ℕ`. The new `ExprMap.findDefeq` consults the hash cache first (syntactic equality, O(1)); on miss it falls back to the original `isDefEq` list scan. The list stays authoritative; the hash map is purely an acceleration structure populated through `push` so its entries always agree with the most recent list entry for the same syntactic key.

Wall-clock `tactic execution` (5 invocations per file, `set_option profiler true`, median of 5 runs):

| benchmark              | before   | after   | speedup |
|------------------------|---------:|--------:|--------:|
| Size20 fast            |  17.4 ms |  16.4 ms | 1.06×   |
| Size80 baseline (ring1)| ~346 ms  | 217 ms  | 1.59×   |
| Size80 fast discharger | 305 ms   | 213 ms  | 1.43×   |
| Size160 fast (3 inv.)  | 503 ms   | 291 ms  | 1.73×   |

The speedup grows with the number of distinct atoms because the old cost was quadratic in atom count. Both the legacy `ring1` discharger path and the fast discharger path benefit (atomization is shared).

`MathlibTest/Linarith/{Basic,NNReal}.lean` and `Benchmark/StageProfile80.lean` pass with 5/5 successes, 0 fallbacks. Codex-reviewed.

This is part of kim-em/soplex#155. An earlier sub-task B (`mkAppN → mkApp{n}` in FastDischarger.lean) was also tried but only moved discharger-stage timers by ~4%, with no measurable wall-clock impact — it has been stripped from this PR per Kim's "no extraneous changes" rule.

Profile breakdown that identified `findDefeq` as the target (from `set_option trace.linarith.detail true`, divided by ~5× trace inflation to estimate no-trace times):

| stage | est. ms/call | fraction |
|---|---:|---:|
| Simplex oracle (`Invoking oracle`) | ~30 ms | **~44%** |
| `linearFormsAndMaxVar` (atomization) | ~10 ms | **~15%** |
| Preprocessors | ~5 ms | ~8% |
| `proveEqZeroUsing` (discharger) | ~5 ms | ~7% |
| `mkLTZeroProof` | ~4 ms | ~5% |
| Other | ~14 ms | ~21% |

The next-biggest target is the Lean-implemented simplex oracle (~44%). That requires either a smarter algorithm or an FFI-based oracle — invasive, separate PR territory.

🤖 Prepared with Claude Code